### PR TITLE
Add support for evaluating private F# unions & records

### DIFF
--- a/Unquote/Evaluation.fs
+++ b/Unquote/Evaluation.fs
@@ -183,9 +183,9 @@ let eval env expr =
             evalAll env args |> Seq.iteri(fun i e -> arrSet.Invoke(arr, [|box i; box e|]) |> ignore)
             box arr
         | P.NewRecord(ty, args) ->
-            FSharpValue.MakeRecord(ty, evalAll env args)
+            FSharpValue.MakeRecord(ty, evalAll env args, true)
         | P.NewUnionCase(uci, args) -> 
-            FSharpValue.MakeUnion(uci, evalAll env args)
+            FSharpValue.MakeUnion(uci, evalAll env args, true)
         | P.NewTuple(args) ->
             FSharpValue.MakeTuple(evalAll env args, expr.Type)
         | P.WhileLoop(condition, body) ->
@@ -207,7 +207,7 @@ let eval env expr =
             box ()
         | P.UnionCaseTest(target, uci) ->
             let targetObj = eval env target
-            let targetUci,_ = FSharpValue.GetUnionFields(targetObj, uci.DeclaringType)
+            let targetUci,_ = FSharpValue.GetUnionFields(targetObj, uci.DeclaringType, true)
             (targetUci.Tag = uci.Tag) |> box
         | P.TryWith(tryBody, _, _, catchVar, catchBody) -> //as far as I can tell the "filter" var and expr exactly the same as the "catch" var and expr except with weird integer return values...
             try

--- a/UnquoteTests/EvaluationTests.fs
+++ b/UnquoteTests/EvaluationTests.fs
@@ -179,6 +179,8 @@ let ``Let and Var with multiple assignments`` () =
 
 type RecordTest = {X:int; Y:string}
 
+type private PrivateRecordTest = {PX:int; PY:string}
+
 [<Fact>]
 let ``NewRecord with fields constructed in order`` () =
     testEval <@ {X=0; Y=""} @> {X=0; Y=""}
@@ -187,6 +189,10 @@ let ``NewRecord with fields constructed in order`` () =
 [<Fact>]
 let ``NewRecord with fields constructed out of order`` () =
     testEval <@ {Y=""; X=0} @> {X=0; Y=""}
+
+[<Fact>]
+let ``NewRecord on private type`` () =
+    testEval <@ {PX=0; PY=""} @> {PX=0; PY=""}
 
 [<Fact>]
 let ``Sequential discards lhs and returns rhs`` () =
@@ -341,11 +347,20 @@ let ``ForIntegerRangeLoop with from and to non-Value expressions`` () =
     <@ for i in (0 + 0)..(0 + 10) do sum := !sum + i @> |> eval
     test <@ !sum = Seq.sum {0..10} @>
 
+type private PrivateUnion = A of int * string | B
+
 [<Fact>]
 let ``UnionCaseTest`` () =
     testEval <@ match Some(3) with
                 | Some(_) -> true
                 | None -> false @>
+             true
+
+[<Fact>]
+let ``PrivateUnionCaseConstruction`` () =
+    testEval <@ match A(2,"") with
+                | A(2,_) -> true
+                | _ -> false @>
              true
 
 [<Fact>]

--- a/UnquoteTests/EvaluationTests.fs
+++ b/UnquoteTests/EvaluationTests.fs
@@ -181,6 +181,11 @@ type RecordTest = {X:int; Y:string}
 
 type private PrivateRecordTest = {PX:int; PY:string}
 
+type private PrivateClassTest internal (x : int, y : string) =
+    member internal __.GetY() = y
+    member val internal X = x with get, set
+    static member internal Test() = ()
+
 [<Fact>]
 let ``NewRecord with fields constructed in order`` () =
     testEval <@ {X=0; Y=""} @> {X=0; Y=""}
@@ -193,6 +198,30 @@ let ``NewRecord with fields constructed out of order`` () =
 [<Fact>]
 let ``NewRecord on private type`` () =
     testEval <@ {PX=0; PY=""} @> {PX=0; PY=""}
+
+[<Fact>]
+let ``Private Class Constructor`` () =
+    testEval <@ new PrivateClassTest(42, "42") |> ignore @> ()
+
+[<Fact>]
+let ``Private Property Getter`` () =
+    let c = new PrivateClassTest(42, "42") 
+    testEval <@ c.X = 42 @> true
+
+[<Fact>]
+let ``Private Property Setter`` () =
+    let c = new PrivateClassTest(42, "42") 
+    testEval <@ c.X <- 0 ; c.X @> 0
+
+[<Fact>]
+let ``Private Instance Method`` () =
+    let c = new PrivateClassTest(42, "42") 
+    testEval <@ c.GetY() @> "42"
+
+[<Fact>]
+let ``Private Static Method`` () =
+    testEval <@ PrivateClassTest.Test() @> ()
+
 
 [<Fact>]
 let ``Sequential discards lhs and returns rhs`` () =


### PR DESCRIPTION
Not sure whether by design, but currently unquote seems to be failing when evaluating private F# unions & records. This PR attempts to address the issue.