### PR TITLE
Add support for rendering `ValueWithName` expressions in the decompiler

### DIFF
--- a/Unquote/Decompilation.fs
+++ b/Unquote/Decompilation.fs
@@ -173,6 +173,7 @@ let decompile expr =
             applyParens OP.LessThanOp (sprintf "%s <- %s" (decompileFieldAccess target fi) (decompile CC.Zero rhs))
         | DP.Unit -> "()" //must come before Value pattern
         | EP.LambdaValue(name) -> ER.sourceNameFromString name
+        | P.ValueWithNameBackCompat(_,_,id) -> id
         | P.Value(o, ty) ->
             match o with
             | null when ty |> ER.isGenericTypeDefinedFrom<option<_>> -> "None" //option<_> None is represented as null

--- a/Unquote/Decompilation.fs
+++ b/Unquote/Decompilation.fs
@@ -173,7 +173,7 @@ let decompile expr =
             applyParens OP.LessThanOp (sprintf "%s <- %s" (decompileFieldAccess target fi) (decompile CC.Zero rhs))
         | DP.Unit -> "()" //must come before Value pattern
         | EP.LambdaValue(name) -> ER.sourceNameFromString name
-        | P.ValueWithNameBackCompat(_,_,id) -> id
+        | EP.ValueWithNameBackCompat(_,_,id) -> id
         | P.Value(o, ty) ->
             match o with
             | null when ty |> ER.isGenericTypeDefinedFrom<option<_>> -> "None" //option<_> None is represented as null

--- a/Unquote/ExtraPatterns.fs
+++ b/Unquote/ExtraPatterns.fs
@@ -190,7 +190,7 @@ type private PatDele = Func<Expr, (obj * Type * string) option>
 // without introducing a compile-time dependency to FSharp.Core >= 4.4
 let (|ValueWithNameBackCompat|_|) =
 #if PORTABLE
-    fun (_:Expr) -> Option.None<obj * Type * string>
+    fun (_:Expr) -> Option<obj * Type * string>.None
 #else
     let pmodule = typeof<unit>.Assembly.GetType("Microsoft.FSharp.Quotations.PatternsModule")
     let meth = match pmodule with null -> null | t -> t.GetMethod("ValueWithNamePattern", BindingFlags.Static ||| BindingFlags.Public)

--- a/Unquote/ExtraPatterns.fs
+++ b/Unquote/ExtraPatterns.fs
@@ -189,6 +189,9 @@ type private PatDele = Func<Expr, (obj * Type * string) option>
 // Exposes a runtime-extracted wrapper for Expr.ValueWithName 
 // without introducing a compile-time dependency to FSharp.Core >= 4.4
 let (|ValueWithNameBackCompat|_|) =
+#if PORTABLE
+    fun (_:Expr) -> Option.None<obj * Type * string>
+#else
     let pmodule = typeof<unit>.Assembly.GetType("Microsoft.FSharp.Quotations.PatternsModule")
     let meth = match pmodule with null -> null | t -> t.GetMethod("ValueWithNamePattern", BindingFlags.Static ||| BindingFlags.Public)
     match meth with
@@ -196,3 +199,4 @@ let (|ValueWithNameBackCompat|_|) =
     | meth -> 
         let dele = Delegate.CreateDelegate(typeof<PatDele>, meth) :?> PatDele
         dele.Invoke
+#endif

--- a/Unquote/Utils/Prelude.fs
+++ b/Unquote/Utils/Prelude.fs
@@ -47,9 +47,9 @@ module P =
     // without introducing a compile-time dependency to FSharp.Core >= 4.4
     let (|ValueWithNameBackCompat|_|) =
         let pmodule = typeof<unit>.Assembly.GetType("Microsoft.FSharp.Quotations.PatternsModule")
-        let method = match pmodule with null -> null | t -> t.GetMethod("ValueWithNamePattern", BindingFlags.Static ||| BindingFlags.Public)
-        match method with
+        let meth = match pmodule with null -> null | t -> t.GetMethod("ValueWithNamePattern", BindingFlags.Static ||| BindingFlags.Public)
+        match meth with
         | null -> (fun (_:Expr) -> None)
-        | method -> 
-            let dele = Delegate.CreateDelegate(typeof<PatDele>, method) :?> PatDele
+        | meth -> 
+            let dele = Delegate.CreateDelegate(typeof<PatDele>, meth) :?> PatDele
             dele.Invoke

--- a/Unquote/Utils/Prelude.fs
+++ b/Unquote/Utils/Prelude.fs
@@ -37,19 +37,3 @@ let (|Int|_|) str =
 //http://stackoverflow.com/questions/833180/handy-f-snippets/1477188#1477188
 let (=~) input pattern = 
     input <> null && System.Text.RegularExpressions.Regex.IsMatch(input, pattern)
-
-module P =
-    open System.Reflection
-    open FSharp.Quotations
-
-    type private PatDele = Func<Expr, (obj * Type * string) option>
-    // Exposes a runtime-extracted wrapper for Expr.ValueWithName 
-    // without introducing a compile-time dependency to FSharp.Core >= 4.4
-    let (|ValueWithNameBackCompat|_|) =
-        let pmodule = typeof<unit>.Assembly.GetType("Microsoft.FSharp.Quotations.PatternsModule")
-        let meth = match pmodule with null -> null | t -> t.GetMethod("ValueWithNamePattern", BindingFlags.Static ||| BindingFlags.Public)
-        match meth with
-        | null -> (fun (_:Expr) -> None)
-        | meth -> 
-            let dele = Delegate.CreateDelegate(typeof<PatDele>, meth) :?> PatDele
-            dele.Invoke


### PR DESCRIPTION
This PR adds support for rendering `ValueWithName` expressions in the decompiler. This also fixes an annoying issue we have been experiencing when using Unquote's assertions, namely the following snippet:
```fsharp
open Swensen.Unquote.Assertions

type Foo = { Foo : string ; Bar : int }

let someTest () = 
    let x = { Foo = "foo" ; Bar = 41 }
    test <@ x.Bar = 42 @>
```
Currently results in the following output:
```
Test failed:

{Foo = "foo";
 Bar = 41;}.Bar = 42
41 = 42
false
```
whereas the change improves the formatting into the following:
```
Test failed:

x.Bar = 42
41 = 42
false
```
The point of this change is that in real tests, the object graph referenced by `x` is typically a large object so having failing assertions typically causes the assertion checker to flood output with irrelevant data that happen to be captured by the quotation. I believe that this change slightly improves the situation, allowing us to focus on the actual assertion.