### PR TITLE
New assertion checker: `trap`

### DIFF
--- a/Unquote/Assertions.fs
+++ b/Unquote/Assertions.fs
@@ -205,6 +205,20 @@ let inline raisesWith<'a when 'a :> exn> (expr:Expr) (exnWhen: 'a -> Expr<bool>)
         with 
         | e -> raise e
 
+///Evaluate the given boolean expression: if successful return the value
+///and if exception logs the reduction steps in the following manner
+///1) stdout if fsi mode
+///2) Framework fail methods if xUnit.net (v1 or v2), NUnit, or Fuchu present
+///3) System.Exception if release mode.
+let inline trap (expr:Quotations.Expr<'T>) : 'T =
+    let u = unquote expr
+    match u.ReductionException with
+    | None -> u.FinalReduction |> evalRaw
+    | Some x ->
+        try Internal.testFailed u.Reductions ""
+        with e -> raise e
+        raise x
+
 ///These '?' suffixed operators conflict with F# 3.0's nullable operators and have been replaced by equivalent '!' suffixed operators.
 [<System.Obsolete("These '?' suffixed operators conflict with F# 3.0's nullable operators and have been replaced by equivalent '!' suffixed operators.")>]
 module Obsolete =

--- a/UnquoteTests/AssertionOperatorsTests.fs
+++ b/UnquoteTests/AssertionOperatorsTests.fs
@@ -18,6 +18,7 @@ limitations under the License.
 module AssertionOperatorsTests
 open Xunit
 open Swensen.Unquote
+open System
 
 [<Fact>]
 let ``expect exception`` () =
@@ -44,6 +45,15 @@ let ``raises no exception`` () =
 [<Fact>]
 let ``test failes`` () =
     raises<exn> <@ test <@ 4 = 5 @> @>
+
+
+[<Fact>]
+let ``trap succeeds`` () =
+    test <@ trap <@ 1 + 1 @> = 2 @>
+
+[<Fact>]
+let ``trap fails`` () =
+    raises<exn> <@ trap <@ 1 / 0 @> @>
 
 
 type SideEffects() =


### PR DESCRIPTION
I've been using the following custom assertion checker in my test projects for quite some time:
```fsharp
val trap : Expr<'T> -> 'T
```
This evaluates the expression tree as normal, returning the result if successful but outputing the full evaluation metadata if exceptional. This can be quite useful for asserting preconditions during a test run, e.g.
```fsharp
let! response1 = server.Get()
let interestingPart = trap <@ response1.Value.items.[42] @>
let! response2 = server.Post interestingPart
test <@ expected = response2 @>
````
Notice how `trap` gives me the confidence of performing unsafe lookups like `.Value` and `.[42]` since any failure will render as a nice assertion exception.