### PR TITLE
issue 144: Fix point free op decompilation

### DIFF
--- a/Unquote/ExtraPatterns.fs
+++ b/Unquote/ExtraPatterns.fs
@@ -45,7 +45,9 @@ let (|LambdaValue|_|) = function
 ///Must come before Call pattern.
 let (|InfixCallOrApplication|_|) = function
     //when the op is compiled as a property            | when the op is a local lambda
-    | P.Call (_, MethodInfoName(opName), lhs::rhs::[]) | P.Application(P.Application(LambdaValue(opName), lhs), rhs) ->
+    | P.Call (_, MethodInfoName(opName), lhs::rhs::[]) 
+    | P.Application(P.Application(LambdaValue(opName), lhs), rhs)
+    | P.Application(P.Application(P.Call(_, MethodInfoName(opName), []), lhs), rhs) ->
         match ER.SymbolicOps.tryFindByName opName with
         | Some(op, ER.SymbolicOps.Infix(prec)) -> Some((op,prec),lhs,rhs)
         | _ -> None

--- a/UnquoteTests/DecompilationTests.fs
+++ b/UnquoteTests/DecompilationTests.fs
@@ -1234,6 +1234,15 @@ let ``issue 1: custom infix op precedence taken from leading symbol`` () =
     <@  1 + 2 +++ 3 @> |> decompile =! "1 + 2 +++ 3"
 
 [<AutoOpen>]
+module EqualTest =
+    let (==) = (=)
+
+[<Fact>]
+let ``issue 144 : custom operator defined as point free function`` () =
+    <@ 1 == 2 @> |> decompile =! "1 == 2"
+
+
+[<AutoOpen>]
 module Issue1_TopLevel =
     let (~~~~~) x = x : int
     [<Fact>]


### PR DESCRIPTION
Fix #144 

The InfixCallOrApplication active pattern didn't check for one by one arguments application.
