### PR TITLE
Decompile Record construction

### DIFF
--- a/Unquote/Decompilation.fs
+++ b/Unquote/Decompilation.fs
@@ -198,6 +198,14 @@ let decompile expr =
             args |> decompileTupledArgs |> sprintf "(%s)" //what is precedence? 10?
         | P.NewArray(_,args) ->
             args |> decompileSequencedArgs |> sprintf "[|%s|]"
+        | P.NewRecord(t,args) ->
+            let fields = FSharpType.GetRecordFields(t)
+            (fields,args)
+            ||> Seq.map2 (fun f x -> sprintf "%s = %s" f.Name (decompile (OP.Semicolon, OP.Non) x))
+            |> String.concat "; "
+            |> sprintf "{ %s }"
+
+
         //list union cases more complex than normal union cases since need to consider
         //both cons infix operator and literal list constructions.
         | P.NewUnionCase(uci,args) when uci |> ER.isListUnionCase ->

--- a/UnquoteTests/DecompilationTests.fs
+++ b/UnquoteTests/DecompilationTests.fs
@@ -1391,3 +1391,12 @@ let ``decompile string``() =
     ]
     let wrap x = "\"" + x + "\""
     test <@ in_out |> List.map (fun (x,y) -> decompile x, wrap y) |> List.map (fun (x,y) -> x = y) |> List.forall id @>
+
+type TestRecord =
+    { Text: string
+      Value: int }
+
+[<Fact>]
+let ``decompile record construction``() =
+    <@ { Text = "Hello"; Value = 42 } @>
+    |> decompile =! """{ Text = "Hello"; Value = 42 }"""


### PR DESCRIPTION
This PR improves the decompilation of Records constucts. 

Previously it looked like 'NewRecord Record("hello",42)'

It  is now ' { Text = "hello"; Value = 42}' which is way nicer 😸 