### PR TITLE
Issue #155: decompile DateTime with higher precision

### DIFF
--- a/src/Unquote/Decompilation.fs
+++ b/src/Unquote/Decompilation.fs
@@ -179,6 +179,8 @@ let decompile expr =
                 sprintf "%A" x.InnerException
             | :? Exception as x ->
                 sprintf "%s: %s" (x.GetType().FullName) x.Message
+            | :? DateTime as x ->
+                x.ToUniversalTime().ToString("o", System.Globalization.CultureInfo.InvariantCulture)
             | _ -> sprintf "%A" o
         | P.NewTuple(args) -> //tuples have at least two elements
             args |> decompileTupledArgs |> sprintf "(%s)" //what is precedence? 10?

--- a/src/Unquote/Decompilation.fs
+++ b/src/Unquote/Decompilation.fs
@@ -180,7 +180,12 @@ let decompile expr =
             | :? Exception as x ->
                 sprintf "%s: %s" (x.GetType().FullName) x.Message
             | :? DateTime as x ->
-                x.ToUniversalTime().ToString("o", System.Globalization.CultureInfo.InvariantCulture)
+                sprintf
+                    "%s (%A)"
+                    (x.ToString("o", System.Globalization.CultureInfo.InvariantCulture))
+                    x.Kind
+            | :? DateTimeOffset as x ->
+                x.ToString("o", System.Globalization.CultureInfo.InvariantCulture)
             | _ -> sprintf "%A" o
         | P.NewTuple(args) -> //tuples have at least two elements
             args |> decompileTupledArgs |> sprintf "(%s)" //what is precedence? 10?

--- a/src/Unquote/Unquote.fsproj
+++ b/src/Unquote/Unquote.fsproj
@@ -28,7 +28,6 @@
     <Compile Include="Operators.fs" />
     <Compile Include="AssertionFailedException.fs" />
     <Compile Include="Assertions.fs" />
-    <Content Include="packages.config" />
     <None Include="Unquote.nuspec" />
   </ItemGroup>
 

--- a/test/UnquoteTests/DecompilationTests.fs
+++ b/test/UnquoteTests/DecompilationTests.fs
@@ -1444,7 +1444,15 @@ let ``decompile mixed WITH anonymous record construction with multiple values``(
     |> decompile =! "let Value = 43 in {| SecondVal = 44; Text = x.Text; Value = Value |}"
 
 [<Fact>]
-let ``issue 115: higher precision DateTime decompilation`` () =
-    let expected = "2021-05-18T12:06:18.1234567Z"
-    let dt = DateTime.Parse(expected)
+let ``issue 115: higher precision DateTime decompilation with Kind`` () =
+    let input = "2021-05-18T12:06:18.1234567Z"
+    let dt = DateTimeOffset.Parse(input).UtcDateTime
+    let expected = input + " (Utc)"
+    test <@ <@ dt @> |> decompiledReductionAt 1 = expected @>
+
+[<Fact>]
+let ``issue 115: higher precision DateTimeOffset decompilation`` () =
+    let input = "2021-05-18T12:06:18.1234567+00:00"
+    let dt = DateTimeOffset.Parse(input)
+    let expected = input
     test <@ <@ dt @> |> decompiledReductionAt 1 = expected @>

--- a/test/UnquoteTests/DecompilationTests.fs
+++ b/test/UnquoteTests/DecompilationTests.fs
@@ -2,7 +2,10 @@
 module DecompilationTests
 open Xunit
 open Swensen.Unquote
-open Swensen.Utils
+
+let decompiledReductionAt i q =
+    let unquoted = q |> unquote
+    unquoted.DecompiledReductions.[i]
 
 let toTypedExprValue<'a> (x: 'a) : Microsoft.FSharp.Quotations.Expr<'a> =
     let x = Microsoft.FSharp.Quotations.Expr.Value(x)
@@ -1439,3 +1442,9 @@ let ``decompile mixed WITH anonymous record construction with multiple values``(
     let x = { Text = "Hello"; Value = 42 }
     <@ {| x with Value = 43; SecondVal = 44 |} @>
     |> decompile =! "let Value = 43 in {| SecondVal = 44; Text = x.Text; Value = Value |}"
+
+[<Fact>]
+let ``issue 115: higher precision DateTime decompilation`` () =
+    let expected = "2021-05-18T12:06:18.1234567Z"
+    let dt = DateTime.Parse(expected)
+    test <@ <@ dt @> |> decompiledReductionAt 1 = expected @>


### PR DESCRIPTION
See #155

Use this UTC / ISO format: `x.ToUniversalTime().ToString("o", System.Globalization.CultureInfo.InvariantCulture)`

TODO: Maybe implement for `DateTimeOffset` if needed