### PR TITLE
Reduce min FSharp.Core version to 6.0.0

### DIFF
--- a/src/Unquote/Unquote.fsproj
+++ b/src/Unquote/Unquote.fsproj
@@ -5,6 +5,7 @@
     <NuSpecFile>Unquote.nuspec</NuSpecFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <Version>7.0.0</Version>
   </PropertyGroup>
 
@@ -32,7 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.100" />
+    <!-- Relatively conservative dependency to avoid cascading dependencies downstream -->
+    <PackageReference Update="FSharp.Core" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Unquote/Unquote.nuspec
+++ b/src/Unquote/Unquote.nuspec
@@ -19,7 +19,7 @@ Unquote integrates configuration-free with all exception-based unit testing fram
 In addition to its unit testing features, Unquote includes operators for evaluating, decompiling, and incrementally reducing quoted expressions.</description>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="FSharp.Core" version="8.0.100"></dependency>
+        <dependency id="FSharp.Core" version="6.0.0"></dependency>
       </group>
     </dependencies>
     <releaseNotes>https://github.com/SwensenSoftware/unquote/wiki/ReleaseNotes</releaseNotes>


### PR DESCRIPTION
Reduces the minimum FSharp.Core version dependency of the core package to 6.0.0 in order to avoid triggering cascading dependency updates in libraries such as Argu and [`FSharp.AWS.DynamoDB`](https://github.com/fsprojects/FSharp.AWS.DynamoDB)

resolves #169 